### PR TITLE
Fix segmentation fault with "--help" (issue #6)

### DIFF
--- a/src/pulsemixer.cpp
+++ b/src/pulsemixer.cpp
@@ -12,7 +12,8 @@
 int main(int argc, char *argv[])
 {
     static const struct option longOpts[] = {
-        { "version", no_argument, 0, 'v' }
+        { "version", no_argument, 0, 'v' },
+        { 0, 0, 0, 0 }
     };
     
     int c;


### PR DESCRIPTION
When running ncpamixer with an unknown long option, e.g., "--help", it segfaults. The man page states that "the last element of the array has to be filled with zeros". The file change does exactly this.