### PR TITLE
Add mouse support

### DIFF
--- a/src/ui/tab.hpp
+++ b/src/ui/tab.hpp
@@ -29,6 +29,7 @@ public:
 
     virtual void draw();
     void handleEvents(const char *event);
+    void handleMouse(int x, int y, int button);
 
     static void borderBox(int w, int h, int px, int py);
     static void selectBox(int w, int px, int py, bool selected);
@@ -76,6 +77,43 @@ private:
     );
     static unsigned int getVolumeColor(int p);
     static unsigned int getBarColor(int p);
+
+    int getBlockSize();
+    bool handleMouseVolumeBar(
+        PaObject* item,
+        int mousex,
+        int mousey,
+        int w,
+        int h,
+        int x,
+        int y
+    );
+    bool handleMouseDropDown(
+        PaObject* item,
+        int mousex,
+        int mousey,
+        int w,
+        int h,
+        int x,
+        int y
+    );
+    bool handleMouseMoreUp(
+        int mousex,
+        int mousey,
+        int w,
+        int h,
+        int x,
+        int y
+    );
+    bool handleMouseMoreDown(
+        int mousex,
+        int mousey,
+        int w,
+        int h,
+        int x,
+        int y
+    );
+    void handleDropDown(PaObject* selected_pobj);
 
     int selected_block;
     int total_blocks;


### PR DESCRIPTION
This PR adds mouse support to ncpamixer.

What's supported:

* clicking on the volume bar to change the volume
* clicking on the sink at the right to select it
   * click on the sink name
   * use the wheel to scroll through names on longer dropdown lists
   * click outside of the dropdown to cancel
* clicking on tab names to switch tabs
* using the wheel to scroll through tabs

What's currently not supported:

* Mute - I considered making it mute when clicking on the percentage number, but it would take some redundant code to recalculate the position (or extra data to store it), plus it would not be obvious that this is the mute option
* Switching the selected "diamond" option - I think for that the UI would have to be changed a bit to make it appear as radio buttons (i.e. it needs something on the inactive options that you could click on — e.g. `( )` vs `(x)`)
* Quitting the program - I considered adding an `Exit` option at the bottom right, but I didn't want this initial PR to make any UI changes (can add this if it's fine by you)

Mouse support requires ncurses 5.0+ (I think) and wheel support requires ncurses 6.0+, so I made that both optional via #ifdefs.