### PR TITLE
Fix build on termux

### DIFF
--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -1,5 +1,6 @@
 #include "ui.hpp"
 
+#include <locale.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 


### PR DESCRIPTION
There is also `wordexp.h` missing in `/data/data/com.termux` but that depends on them.