### PR TITLE
Fix segfault on new playback sink creation on PipeWire

### DIFF
--- a/src/pa.cpp
+++ b/src/pa.cpp
@@ -582,19 +582,8 @@ void Pa::create_monitor_stream_for_paobject(PaObject *po)
         po->monitor_stream = nullptr;
     }
 
-    if (po->type == pa_object_t::INPUT) {
-        PaInput *input = reinterpret_cast<PaInput *>(po);
-        input->monitor_stream = create_monitor_stream_for_source(
-                                    PA_SINKS[input->sink]->monitor_index,
-                                    input->index
-                                );
-    } else {
-        po->monitor_stream = create_monitor_stream_for_source(
-                                 po->monitor_index,
-                                 -1
-                             );
-
-    }
+	po->monitor_stream = create_monitor_stream_for_source
+		(po->monitor_index, po->type == pa_object_t::INPUT ? po->index : -1);
 }
 
 void Pa::set_notify_update_cb(const notify_update_callback &cb)


### PR DESCRIPTION
When running ncpamixer under pipewire-pulse, ncpamixer segfaults when creating a new playback stream sink. After running a debug build with gdb, it appeared that the segfault was occurring when PA_SINKS was being accessed, so after switching to just using po->monitor_index, ncpamixer no longer segfaulted and everything still appears to be working perfectly. Also I removed the cast of po to PaInput because it does not appear to be necessary for the volume bar to function properly.