### PR TITLE
Add build dependencies for Debian(-based) systems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ You find them in ncpamixer.conf
 * CMake
 * C++14 compatible compiler
 
+On Debian(-based) systems, you'd need `libncurses-dev` and `libpulse-dev`.
+
 ### Install
 
 ##### Arch Linux


### PR DESCRIPTION
Fixes #24.

In my opinion it's easier to see it right in the build instructions then to find the issue. Even though it's pinned, I initially overlooked it.

Signed-off-by: Diederik de Haas <github@cknow.org>