### PR TITLE
Fixed crash when stream is deleted and then written to anyway

### DIFF
--- a/src/pa.cpp
+++ b/src/pa.cpp
@@ -504,7 +504,7 @@ void Pa::read_callback(pa_stream *s, size_t length, void *instance)
 
     uint32_t input_idx = pa_stream_get_monitor_stream(s);
 
-    if (input_idx != PA_INVALID_INDEX) {
+    if (input_idx != PA_INVALID_INDEX && pa->PA_INPUTS.find(input_idx) != pa->PA_INPUTS.end()) {
         pa->PA_INPUTS[input_idx]->peak = v;
     } else {
         pa->updatePeakByDeviceId(pa_stream_get_device_index(s), v);


### PR DESCRIPTION
I've had a persistent problem with ncpamixer where it would occasionally just crash if left open on my system. I decided to debug this problem a few weeks ago and found the cause, although probably not the _root_ cause. The issue develops like this:

1. A particular Proton game is launched via Steam.
2. This game does _something_ to PulseAudio. I haven't been able to figure out exactly what but it causes all system audio to stop momentarily during startup.
3. Simultaneously (I'm not sure of the exact timing) `Pa::ctx_inputlist_cb` is invoked with a new stream index, causing a new entry in `Pa::PA_INPUTS` to be created.
4. Soon after that `Pa::subscribe_cb` is invoked with an event of types `PA_SUBSCRIPTION_EVENT_SINK_INPUT` and `PA_SUBSCRIPTION_EVENT_REMOVE`. This causes the entry in `Pa::PA_INPUTS` to be removed.
5. Then, presumably whenever the stream next delivers an audio packet, `Pa::read_callback` is invoked. This function proceeds until it tries to set `PaObject::peak`. It assumes that `Pa::PA_INPUTS` will always contain an entry for any valid index it encounters and so tries to access it without checking for its existence. `std::map::operator[]` creates a new entry which is an invalid pointer. This is immediately dereferenced causing a segmentation fault.

This pull request fixes this problem by adding a check for the existence of the `Pa::PA_INPUTS` entry prior to dereferencing. A better pull request would probably address this differently but I don't understand enough about the inner workings of the PulseAudio protocol to write it. I'm available to run more tests if you need me to.

Regarding the game that triggers this the example I'm aware of right now is [Halo: The Master Chief Collection](https://store.steampowered.com/app/976730/Halo_The_Master_Chief_Collection/) though I think there were others in the past. This is a Windows-native game running via Proton which suggests this isn't something the game is doing directly (the game knows nothing about PulseAudio) but rather something it asks Proton to do.